### PR TITLE
Update ObjectSelectorWindow.cs

### DIFF
--- a/Editor/ObjectSelectorWindow.cs
+++ b/Editor/ObjectSelectorWindow.cs
@@ -98,7 +98,7 @@ namespace AYellowpaper.Editor
 
         private void InitVisualElements()
         {
-            var styleSheet = AssetDatabase.LoadAssetAtPath<StyleSheet>("Assets/SerializeInterfaces/Assets/USS/ObjectSelectorWindow.uss");
+            var styleSheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(AssetDatabase.GUIDToAssetPath("5750d2656cea8ea488662fef0bdedbe5"));
             rootVisualElement.styleSheets.Add(styleSheet);
 
             _searchbox = new ToolbarSearchField();


### PR DESCRIPTION
Your package already includes the .meta files which you can use them to find without iterating through every directory. The Unity is smart enough to know if there is an asset which has the same GUID and gives an error on the console. But that is nearly impossible because a GUID is too big.